### PR TITLE
fix: update curl to follow redirections

### DIFF
--- a/core/common.php
+++ b/core/common.php
@@ -137,7 +137,8 @@ class common
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $maxmind_db_url);	// Fetch using this URL
 		curl_setopt($ch, CURLOPT_HEADER, 0);		// MaxMind server doesn't need HTTP headers
-		curl_setopt($ch, CURLOPT_FILE, $fp);				// Write file here
+		curl_setopt($ch, CURLOPT_FILE, $fp);		// Write file here
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);	// Follows redirection due to MaxMind update using R2
 
 		// Get the database over the internet and write it to a file
 		$success = curl_exec($ch);


### PR DESCRIPTION
Due to MaxMind update on the 1st May 2024 :
```txt
Hello,

As of Wednesday, May 1, 2024, all MaxMind database downloads will redirect to R2 presigned URLs. We are making this change in order to increase the security and reliability of our services. 

This is a potentially breaking change. Please ensure your downloading HTTP client is configured to follow redirects and can connect to the following hostname:

mm-prod-geoip-databases.a2649acb697e2c09b632799562c076f2.r2.cloudflarestorage.com

We recommend confirming the above as early as possible.

You do not need to change the URL you download from. Existing permalinks will continue to work.
```

The file is downloaded after recieving a 302 👌

Following the discussion in https://www.phpbb.com/customise/db/extension/filterbycountry/support/topic/246766 

Thank you for the suggestion [DSC](https://www.phpbb.com/customise/db/extension/filterbycountry/support/topic/246766?p=878371#p878371)